### PR TITLE
[IMP].vimrc: relative line numbers

### DIFF
--- a/editors/vim/.vimrc
+++ b/editors/vim/.vimrc
@@ -1,5 +1,6 @@
 set nocompatible
-set number 
+set number
+set relativenumbers
 
 set ignorecase
 set smartcase


### PR DESCRIPTION
This is meant to force me to use things like 7j rather than jjjjjjj